### PR TITLE
fix: keep editing duration after title blur

### DIFF
--- a/src/test/meeting-view.test.tsx
+++ b/src/test/meeting-view.test.tsx
@@ -137,6 +137,37 @@ describe("MeetingView", () => {
         expect(topic2).toPrecede(newTopic);
       });
 
+      it("should allow entering duration after title when creating a topic", async () => {
+        if (!testMeeting) {
+          throw new Error("Test meeting not set up");
+        }
+
+        const addTopicButton = screen.getByRole("button", {
+          name: "Add Topic",
+        });
+        await userEvent.click(addTopicButton);
+
+        const titleInput = screen.getByRole("textbox", { name: "Topic" });
+        await userEvent.type(titleInput, "Timed Topic");
+        await userEvent.keyboard("{Tab}");
+
+        const durationInput = screen.getByRole("spinbutton", {
+          name: "Duration",
+        });
+        await userEvent.clear(durationInput);
+        await userEvent.type(durationInput, "15");
+        fireEvent.blur(durationInput);
+
+        expect(
+          screen.getByRole("heading", { name: "Timed Topic" })
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText((_, element) => {
+            return element?.textContent === "12:00 PM for 15 minutes";
+          })
+        ).toBeInTheDocument();
+      });
+
       it("should allow deleting topics", async () => {
         if (!testMeeting) {
           throw new Error("Test meeting not set up");

--- a/src/ui/doc/TopicNode.tsx
+++ b/src/ui/doc/TopicNode.tsx
@@ -61,9 +61,6 @@ export const TopicNode: FC<TopicNodeProps> = ({
               value={topic.title}
               onValueChange={(newValue) => {
                 topic.title = newValue;
-                if (isDraft && onPublish) {
-                  onPublish();
-                }
                 if (topic.title === "" && isDraft && onCancel) {
                   onCancel();
                 }
@@ -82,6 +79,9 @@ export const TopicNode: FC<TopicNodeProps> = ({
                 editingByDefault={isDraft}
                 onValueChange={(newDuration) => {
                   topic.durationMinutes = newDuration;
+                  if (isDraft && onPublish) {
+                    onPublish();
+                  }
                 }}
                 autoFocus={!isDraft}
                 canEdit={canEdit}


### PR DESCRIPTION
## Summary
- publish draft topics after setting duration instead of on title blur
- test creating a topic by filling title then duration

## Testing
- `npx eslint .`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689125f961f8832180ac34621327b17b