### PR TITLE
feat: add calendar view for meetings

### DIFF
--- a/src/test/meeting-list.test.tsx
+++ b/src/test/meeting-list.test.tsx
@@ -62,6 +62,85 @@ describe("Meeting List", () => {
       ).toBeInTheDocument();
     });
 
+    it("should show meetings in calendar view when toggled", async () => {
+      const today = new Date();
+      const meetingDate = new Date(
+        today.getFullYear(),
+        today.getMonth(),
+        today.getDate(),
+        12,
+        0,
+        0
+      );
+      await addTestMeeting(meetingDate);
+
+      await render(<App />, { startingPath: "/meetings" });
+
+      const calendarButton = screen.getByRole("button", { name: "Calendar" });
+      await userEvent.click(calendarButton);
+
+      expect(
+        screen.getByRole("link", {
+          name: meetingDate.toLocaleDateString(),
+        })
+      ).toBeInTheDocument();
+    });
+
+    it("should navigate months in calendar view", async () => {
+      const today = new Date();
+      const previousMonthDate = new Date(
+        today.getFullYear(),
+        today.getMonth() - 1,
+        10,
+        12,
+        0,
+        0
+      );
+      const nextMonthDate = new Date(
+        today.getFullYear(),
+        today.getMonth() + 1,
+        10,
+        12,
+        0,
+        0
+      );
+      await addTestMeeting(previousMonthDate);
+      await addTestMeeting(nextMonthDate);
+
+      await render(<App />, { startingPath: "/meetings" });
+
+      const calendarButton = screen.getByRole("button", { name: "Calendar" });
+      await userEvent.click(calendarButton);
+
+      expect(
+        screen.queryByRole("link", {
+          name: previousMonthDate.toLocaleDateString(),
+        })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("link", {
+          name: nextMonthDate.toLocaleDateString(),
+        })
+      ).not.toBeInTheDocument();
+
+      const prevButton = screen.getByRole("button", { name: "<" });
+      await userEvent.click(prevButton);
+      expect(
+        screen.getByRole("link", {
+          name: previousMonthDate.toLocaleDateString(),
+        })
+      ).toBeInTheDocument();
+
+      const nextButton = screen.getByRole("button", { name: ">" });
+      await userEvent.click(nextButton); // back to current
+      await userEvent.click(nextButton); // move to next month
+      expect(
+        screen.getByRole("link", {
+          name: nextMonthDate.toLocaleDateString(),
+        })
+      ).toBeInTheDocument();
+    });
+
     it("should not be able to create meeting", async () => {
       await render(<App />, { startingPath: "/meetings" });
 

--- a/src/views/meeting/MeetingCalendar.css
+++ b/src/views/meeting/MeetingCalendar.css
@@ -1,0 +1,18 @@
+.meeting-calendar table {
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
+  border: 1px solid var(--secondary-color);
+}
+
+.meeting-calendar th,
+.meeting-calendar td {
+  width: calc(100% / 7);
+  padding: 4px;
+  vertical-align: top;
+  border: 1px solid var(--secondary-color);
+}
+
+.meeting-calendar td.outside-month {
+  opacity: 0.5;
+}

--- a/src/views/meeting/MeetingCalendar.tsx
+++ b/src/views/meeting/MeetingCalendar.tsx
@@ -1,0 +1,111 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import "./MeetingCalendar.css";
+
+interface Meeting {
+  id: string;
+  date?: Date | null;
+}
+
+interface MeetingCalendarProps {
+  meetings: Meeting[];
+}
+
+const buildWeeks = (current: Date) => {
+  const year = current.getFullYear();
+  const month = current.getMonth();
+  const firstOfMonth = new Date(year, month, 1);
+  const start = new Date(firstOfMonth);
+  start.setDate(firstOfMonth.getDate() - firstOfMonth.getDay());
+
+  const weeks: Date[][] = [];
+  const day = new Date(start);
+  for (let w = 0; w < 6; w++) {
+    const week: Date[] = [];
+    for (let d = 0; d < 7; d++) {
+      week.push(new Date(day));
+      day.setDate(day.getDate() + 1);
+    }
+    weeks.push(week);
+  }
+  return weeks;
+};
+
+export const MeetingCalendar = ({ meetings }: MeetingCalendarProps) => {
+  const [currentMonth, setCurrentMonth] = useState(() => {
+    const now = new Date();
+    return new Date(now.getFullYear(), now.getMonth(), 1);
+  });
+
+  const weeks = buildWeeks(currentMonth);
+  const month = currentMonth.getMonth();
+
+  const meetingsByDay = new Map<string, Meeting[]>();
+  meetings.forEach((m) => {
+    if (!m.date) return;
+    const key = `${m.date.getFullYear()}-${m.date.getMonth()}-${m.date.getDate()}`;
+    const arr = meetingsByDay.get(key) ?? [];
+    arr.push(m);
+    meetingsByDay.set(key, arr);
+  });
+
+  const prevMonth = () =>
+    setCurrentMonth(
+      new Date(currentMonth.getFullYear(), currentMonth.getMonth() - 1, 1)
+    );
+  const nextMonth = () =>
+    setCurrentMonth(
+      new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 1)
+    );
+
+  const weekdayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+  return (
+    <div className="meeting-calendar">
+      <div className="navigation">
+        <button onClick={prevMonth}>{"<"}</button>
+        <span>
+          {currentMonth.toLocaleString("default", {
+            month: "long",
+            year: "numeric",
+          })}
+        </span>
+        <button onClick={nextMonth}>{">"}</button>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            {weekdayNames.map((d) => (
+              <th key={d}>{d}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {weeks.map((week, i) => (
+            <tr key={i}>
+              {week.map((date, j) => {
+                const key = `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+                const dayMeetings = meetingsByDay.get(key) ?? [];
+                const isCurrentMonth = date.getMonth() === month;
+                return (
+                  <td key={j} className={isCurrentMonth ? "" : "outside-month"}>
+                    <div>{date.getDate()}</div>
+                    {dayMeetings.map((m) => (
+                      <div key={m.id}>
+                        <Link to={`/meetings/${m.id}`}>
+                          {m.date?.toLocaleDateString()}
+                        </Link>
+                      </div>
+                    ))}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {meetings.length === 0 && <p>No meetings have been scheduled yet.</p>}
+    </div>
+  );
+};
+

--- a/src/views/meeting/MeetingList.tsx
+++ b/src/views/meeting/MeetingList.tsx
@@ -4,10 +4,12 @@ import { Link } from "react-router-dom";
 import { SlPlus } from "react-icons/sl";
 import { useLoadedAccount } from "../../hooks/Account";
 import { SubHeader } from "../../ui/SubHeader";
+import { MeetingCalendar } from "./MeetingCalendar";
 
 export const MeetingList = () => {
   const me = useLoadedAccount();
   const [isCreateMeetingOpen, setCreateMeetingOpen] = useState(false);
+  const [view, setView] = useState<"list" | "calendar">("list");
 
   if (!me.root.selectedOrganization) {
     return <p>No organization selected</p>;
@@ -28,25 +30,38 @@ export const MeetingList = () => {
         <CreateMeetingDialog closeDialog={() => setCreateMeetingOpen(false)} />
       )}
       <SubHeader />
-      <ul>
+      <div>
         {isOfficer && (
-          <li>
-            <button onClick={() => setCreateMeetingOpen(true)}>
-              <SlPlus /> Create a new meeting
-            </button>
-          </li>
+          <button onClick={() => setCreateMeetingOpen(true)}>
+            <SlPlus /> Create a new meeting
+          </button>
         )}
-        {myMeetings.map((meeting) => (
-          <li key={meeting.id}>
-            <Link to={`/meetings/${meeting.id}`}>
-              {meeting.date?.toLocaleDateString() ?? "No date"}
-            </Link>
-          </li>
-        ))}
-        {myMeetings.length === 0 && (
-          <li>No meetings have been scheduled yet.</li>
-        )}
-      </ul>
+        <button onClick={() => setView("list")} disabled={view === "list"}>
+          List
+        </button>
+        <button
+          onClick={() => setView("calendar")}
+          disabled={view === "calendar"}
+        >
+          Calendar
+        </button>
+      </div>
+      {view === "list" ? (
+        <ul>
+          {myMeetings.map((meeting) => (
+            <li key={meeting.id}>
+              <Link to={`/meetings/${meeting.id}`}>
+                {meeting.date?.toLocaleDateString() ?? "No date"}
+              </Link>
+            </li>
+          ))}
+          {myMeetings.length === 0 && (
+            <li>No meetings have been scheduled yet.</li>
+          )}
+        </ul>
+      ) : (
+        <MeetingCalendar meetings={myMeetings} />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- toggle between list and calendar views for meetings
- show meetings on monthly calendar with navigation
- calendar starts on the current month and uses equal-width day cells
- calendar styling uses the theme's secondary color and removes inline styles
- test coverage for calendar view toggle and month navigation

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891640378d88321a121ce54fbdf1ad8