### PR TITLE
Expand organization selector width

### DIFF
--- a/src/ui/Header.css
+++ b/src/ui/Header.css
@@ -82,7 +82,7 @@ header {
     align-items: center;
     gap: 5px;
     .organization-selector {
-      flex: 0 1 200px;
+      flex: 0 1 400px;
       min-width: 100px;
     }
 

--- a/src/ui/Header.css
+++ b/src/ui/Header.css
@@ -81,9 +81,13 @@ header {
     flex-direction: row;
     align-items: center;
     gap: 5px;
+    .organization-selector {
+      flex: 0 1 200px;
+      min-width: 100px;
+    }
 
-    select {
-      max-width: 100px;
+    .organization-selector select {
+      width: 100%;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Let organization selector use available space up to 200px without crowding nav

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68919d37e2348321a3966011e5830e27