### PR TITLE
feat: add quick meeting creation from calendar

### DIFF
--- a/src/test/meeting-list.test.tsx
+++ b/src/test/meeting-list.test.tsx
@@ -81,11 +81,10 @@ describe("Meeting List", () => {
 
       expect(
         screen.getByRole("link", {
-          name: meetingDate.toLocaleDateString(),
+          name: "12:00 PM",
         })
       ).toBeInTheDocument();
     });
-
 
     it("should navigate months in calendar view", async () => {
       const today = new Date();
@@ -128,7 +127,7 @@ describe("Meeting List", () => {
       await userEvent.click(prevButton);
       expect(
         screen.getByRole("link", {
-          name: previousMonthDate.toLocaleDateString(),
+          name: "12:00 PM",
         })
       ).toBeInTheDocument();
 
@@ -137,7 +136,7 @@ describe("Meeting List", () => {
       await userEvent.click(nextButton); // move to next month
       expect(
         screen.getByRole("link", {
-          name: nextMonthDate.toLocaleDateString(),
+          name: "12:00 PM",
         })
       ).toBeInTheDocument();
     });

--- a/src/test/meeting-list.test.tsx
+++ b/src/test/meeting-list.test.tsx
@@ -86,6 +86,7 @@ describe("Meeting List", () => {
       ).toBeInTheDocument();
     });
 
+
     it("should navigate months in calendar view", async () => {
       const today = new Date();
       const previousMonthDate = new Date(
@@ -193,6 +194,43 @@ describe("Meeting List", () => {
       expect(
         screen.getByRole("link", { name: "10/8/2023" })
       ).toBeInTheDocument();
+    });
+
+    it("should set date when adding meeting from calendar cell", async () => {
+      const today = new Date();
+      const meetingDate = new Date(
+        today.getFullYear(),
+        today.getMonth(),
+        10,
+        12,
+        0,
+        0
+      );
+      await addTestMeeting(meetingDate);
+
+      await render(<App />, { startingPath: "/meetings" });
+
+      const calendarButton = screen.getByRole("button", { name: "Calendar" });
+      await userEvent.click(calendarButton);
+
+      const targetDate = new Date(
+        today.getFullYear(),
+        today.getMonth(),
+        15,
+        12,
+        0,
+        0
+      );
+
+      const addButton = screen.getByRole("button", {
+        name: `Add meeting on ${targetDate.toLocaleDateString()}`,
+      });
+      await userEvent.click(addButton);
+
+      const meetingDateInput = screen.getByRole<HTMLInputElement>("textbox", {
+        name: "Meeting date",
+      });
+      expect(meetingDateInput.value).toBe(targetDate.toLocaleDateString());
     });
 
     it("should be able to create meeting", async () => {

--- a/src/ui/dialogs/CreateMeetingDialog.tsx
+++ b/src/ui/dialogs/CreateMeetingDialog.tsx
@@ -3,10 +3,12 @@ import { Dialog } from "./Dialog";
 
 export type CreateMeetingDialogProps = {
   closeDialog: () => void;
+  defaultDate?: Date | null;
 };
 
 export const CreateMeetingDialog = ({
   closeDialog,
+  defaultDate = null,
 }: CreateMeetingDialogProps) => {
   return (
     <Dialog
@@ -14,7 +16,7 @@ export const CreateMeetingDialog = ({
       closeDialog={closeDialog}
       className="create-meeting"
     >
-      <CreateMeeting onCreated={closeDialog} />
+      <CreateMeeting onCreated={closeDialog} defaultDate={defaultDate} />
     </Dialog>
   );
 };

--- a/src/ui/forms/Meeting.tsx
+++ b/src/ui/forms/Meeting.tsx
@@ -7,11 +7,15 @@ import { useLoadedAccount } from "../../hooks/Account";
 
 export type CreateMeetingProps = {
   onCreated?: (meeting: Meeting) => void;
+  defaultDate?: Date | null;
 };
 
-export const CreateMeeting: FC<CreateMeetingProps> = ({ onCreated }) => {
+export const CreateMeeting: FC<CreateMeetingProps> = ({
+  onCreated,
+  defaultDate = null,
+}) => {
   const me = useLoadedAccount();
-  const [date, setDate] = useState<Date | null>(null);
+  const [date, setDate] = useState<Date | null>(defaultDate);
   const [time, setTime] = useState<Date | null>(null);
 
   if (!me || !me.root.selectedOrganization) {

--- a/src/views/meeting/MeetingCalendar.css
+++ b/src/views/meeting/MeetingCalendar.css
@@ -39,3 +39,11 @@
   gap: 30px;
   align-items: center;
 }
+
+.meeting-calendar td .add-meeting {
+  margin-top: 4px;
+  background: none;
+  border: none;
+  color: var(--primary-color);
+  cursor: pointer;
+}

--- a/src/views/meeting/MeetingCalendar.css
+++ b/src/views/meeting/MeetingCalendar.css
@@ -1,49 +1,87 @@
-.meeting-calendar table {
-  margin-top: 20px;
-  width: 100%;
-  table-layout: fixed;
-  border-collapse: collapse;
-  border: 1px solid var(--secondary-color);
-}
+.meeting-calendar {
+  table {
+    margin-top: 20px;
+    width: 100%;
+    table-layout: fixed;
+    border-collapse: collapse;
+    border: 1px solid var(--secondary-color);
+  }
 
-.meeting-calendar th,
-.meeting-calendar td {
-  width: calc(100% / 7);
-  padding: 4px;
-  vertical-align: top;
-  border: 1px solid var(--secondary-color);
-}
+  th,
+  td {
+    width: calc(100vw / 7);
+    padding: 4px;
+    vertical-align: top;
+    border: 1px solid var(--secondary-color);
+  }
 
-.meeting-calendar th {
-  background-color: var(--primary-color-subtle);
-  color: var(--font-color);
-  text-align: center;
-}
+  th {
+    background-color: var(--primary-color-subtle);
+    color: var(--font-color);
+    text-align: center;
+  }
 
-.meeting-calendar td {
-  height: calc(60vh / 7);
-}
+  tr {
+    display: flex;
+    flex-direction: row;
+  }
 
-.meeting-calendar td.outside-month {
-  opacity: 0.5;
-}
+  td {
+    height: min(calc(60vh / 7), calc(100vw / 7));
+    position: relative;
+    overflow-x: hidden;
+  }
 
-.meeting-calendar td.today {
-  background-color: var(--primary-color);
-  color: var(--button-foreground);
-}
+  td.outside-month {
+    opacity: 0.5;
+  }
 
-.meeting-calendar .navigation {
-  display: flex;
-  justify-content: center;
-  gap: 30px;
-  align-items: center;
-}
+  td.today {
+    background-color: var(--primary-color);
+    color: var(--button-foreground);
+  }
 
-.meeting-calendar td .add-meeting {
-  margin-top: 4px;
-  background: none;
-  border: none;
-  color: var(--primary-color);
-  cursor: pointer;
+  .navigation {
+    display: flex;
+    justify-content: center;
+    gap: 30px;
+    align-items: center;
+  }
+
+  td .date {
+    position: absolute;
+    top: 0px;
+    left: 4px;
+  }
+
+  td .meetings {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    font-weight: bold;
+    text-wrap: nowrap;
+    font-size: min(3vw, 20px);
+  }
+
+  td button.add-meeting {
+    display: block;
+    width: 100%;
+    height: 100%;
+    background: none;
+    border: none;
+    color: var(--primary-color);
+    cursor: pointer;
+    box-shadow: none;
+  }
+
+  td button.add-meeting:hover {
+    background: none;
+    border: none;
+    box-shadow: none;
+    font-weight: bold;
+    stroke-width: 3px;
+  }
 }

--- a/src/views/meeting/MeetingCalendar.tsx
+++ b/src/views/meeting/MeetingCalendar.tsx
@@ -102,14 +102,18 @@ export const MeetingCalendar = ({
                       (isToday ? " today" : "")
                     }
                   >
-                    <div>{date.getDate()}</div>
-                    {dayMeetings.map((m) => (
-                      <div key={m.id}>
-                        <Link to={`/meetings/${m.id}`}>
-                          {m.date?.toLocaleDateString()}
-                        </Link>
+                    <div className="date">{date.getDate()}</div>
+                    {dayMeetings.length > 0 && (
+                      <div className="meetings">
+                        {dayMeetings.map((m) => (
+                          <Link to={`/meetings/${m.id}`} key={m.id}>
+                            {m.date?.toLocaleTimeString([], {
+                              timeStyle: "short",
+                            }) ?? "No time"}
+                          </Link>
+                        ))}
                       </div>
-                    ))}
+                    )}
                     {dayMeetings.length === 0 && onAddMeeting && (
                       <button
                         aria-label={`Add meeting on ${date.toLocaleDateString()}`}

--- a/src/views/meeting/MeetingCalendar.tsx
+++ b/src/views/meeting/MeetingCalendar.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
+import { SlPlus } from "react-icons/sl";
 import "./MeetingCalendar.css";
 
 interface Meeting {
@@ -9,6 +10,7 @@ interface Meeting {
 
 interface MeetingCalendarProps {
   meetings: Meeting[];
+  onAddMeeting?: (date: Date) => void;
 }
 
 const buildWeeks = (current: Date) => {
@@ -31,7 +33,10 @@ const buildWeeks = (current: Date) => {
   return weeks;
 };
 
-export const MeetingCalendar = ({ meetings }: MeetingCalendarProps) => {
+export const MeetingCalendar = ({
+  meetings,
+  onAddMeeting,
+}: MeetingCalendarProps) => {
   const [currentMonth, setCurrentMonth] = useState(() => {
     const now = new Date();
     return new Date(now.getFullYear(), now.getMonth(), 1);
@@ -105,6 +110,15 @@ export const MeetingCalendar = ({ meetings }: MeetingCalendarProps) => {
                         </Link>
                       </div>
                     ))}
+                    {dayMeetings.length === 0 && onAddMeeting && (
+                      <button
+                        aria-label={`Add meeting on ${date.toLocaleDateString()}`}
+                        onClick={() => onAddMeeting(date)}
+                        className="add-meeting"
+                      >
+                        <SlPlus />
+                      </button>
+                    )}
                   </td>
                 );
               })}

--- a/src/views/meeting/MeetingList.tsx
+++ b/src/views/meeting/MeetingList.tsx
@@ -11,6 +11,7 @@ import { IoCalendarOutline } from "react-icons/io5";
 export const MeetingList = () => {
   const me = useLoadedAccount();
   const [isCreateMeetingOpen, setCreateMeetingOpen] = useState(false);
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const [view, setView] = useState<"list" | "calendar">("list");
 
   if (!me.root.selectedOrganization) {
@@ -29,7 +30,13 @@ export const MeetingList = () => {
   return (
     <div>
       {isCreateMeetingOpen && (
-        <CreateMeetingDialog closeDialog={() => setCreateMeetingOpen(false)} />
+        <CreateMeetingDialog
+          closeDialog={() => {
+            setCreateMeetingOpen(false);
+            setSelectedDate(null);
+          }}
+          defaultDate={selectedDate}
+        />
       )}
       <SubHeader
         tabs={[
@@ -51,7 +58,10 @@ export const MeetingList = () => {
             ? [
                 {
                   label: "Create a new meeting",
-                  onClick: () => setCreateMeetingOpen(true),
+                  onClick: () => {
+                    setSelectedDate(null);
+                    setCreateMeetingOpen(true);
+                  },
                   icon: <SlPlus />,
                 },
               ]
@@ -72,7 +82,17 @@ export const MeetingList = () => {
           )}
         </ul>
       ) : (
-        <MeetingCalendar meetings={myMeetings} />
+        <MeetingCalendar
+          meetings={myMeetings}
+          onAddMeeting={
+            isOfficer
+              ? (date) => {
+                  setSelectedDate(date);
+                  setCreateMeetingOpen(true);
+                }
+              : undefined
+          }
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- allow selecting a default date when creating meetings
- show an add meeting button on empty calendar days to open the dialog pre-filled with that date
- verify calendar cell creation flow with a new test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68919cfee7808321a4bd411e57056f43