### PR TITLE
Soften today highlight and darken add buttons in meeting calendar

### DIFF
--- a/src/views/meeting/MeetingCalendar.css
+++ b/src/views/meeting/MeetingCalendar.css
@@ -37,13 +37,8 @@
   }
 
   td.today {
-    background-color: var(--primary-color);
-    color: var(--button-foreground);
-
-    a,
-    button.add-meeting {
-      color: var(--button-foreground);
-    }
+    background-color: var(--primary-color-light);
+    color: var(--font-color);
   }
 
   .navigation {
@@ -83,7 +78,7 @@
     height: 100%;
     background: none;
     border: none;
-    color: var(--primary-color);
+    color: var(--font-color);
     cursor: pointer;
     box-shadow: none;
     font-size: 18px;


### PR DESCRIPTION
## Summary
- make current day indicator use `primary-color-light`
- render add meeting buttons in default text color

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892b2bb8f9083218ff297edf9ed4a68