### PR TITLE
Use hash router for SPA navigation

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,7 @@ import "./index.css";
 import App from "./App.tsx";
 import { ClerkProvider, useClerk } from "@clerk/clerk-react";
 import { JazzReactProviderWithClerk } from "jazz-tools/react";
-import { BrowserRouter } from "react-router-dom";
+import { HashRouter } from "react-router-dom";
 import { Schema } from "./schema.ts";
 
 const CLERK_PUBLISHABLE_KEY = import.meta.env
@@ -39,9 +39,9 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY} afterSignOutUrl={"/"}>
       <JazzProvider>
-        <BrowserRouter basename={import.meta.env.BASE_URL}>
+        <HashRouter basename={import.meta.env.BASE_URL}>
           <App />
-        </BrowserRouter>
+        </HashRouter>
       </JazzProvider>
     </ClerkProvider>
   </StrictMode>


### PR DESCRIPTION
## Summary
- use `HashRouter` instead of `BrowserRouter` for routing

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68935fd61c548321aa1dd656763ee151