### PR TITLE
Meeting Minutes: Always-Editable, DOCX Export & Integrity Checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@clerk/clerk-react": "^5.4.1",
     "@hello-pangea/dnd": "^18.0.1",
     "convex": "^1.39.1",
+    "docx": "8.2.1",
     "react": "^19.0.0",
     "react-datepicker": "^8.2.1",
     "react-dom": "^19.0.0",

--- a/src/docx/doc.ts
+++ b/src/docx/doc.ts
@@ -1,0 +1,506 @@
+// Ported from butaud/minutes-taker's src/fs/doc.ts. Structure, styles, and
+// wording are kept as close to the original as possible so the exported
+// document looks like minutes-taker's output. Deviations from the original
+// (all driven by real differences in our data model, not stylistic choices):
+//   - No LinkNote support: prepare-to-board doesn't have a link note type.
+//   - makeSeconderParagraph is skipped when a motion has no seconder, since
+//     our motion form treats the seconder as optional.
+//   - makeCallToOrderParagraph and the Session type both tolerate a meeting
+//     with zero recorded topics (the original assumes at least one).
+//   - Person only ever has a lastName (the full name) and an empty
+//     title/firstName - see model.ts for why.
+import {
+  Document,
+  Packer,
+  Paragraph,
+  TextRun,
+  HeadingLevel,
+  Table,
+  TableCell,
+  TableRow,
+  WidthType,
+} from "docx";
+import {
+  ActionItemNote,
+  Calendar,
+  CalendarMonthEntry,
+  Committee,
+  MotionNote,
+  PastActionItem,
+  Person,
+  Session,
+  SessionMetadata,
+  TextNote,
+  Topic,
+} from "./model";
+import {
+  CalendarCellMargins,
+  Styles,
+  TopicHeaderCellMargins,
+  TopicHeaderCellShading,
+} from "./style";
+
+const isTextNote = (note: Topic["notes"][number]): note is TextNote => note.type === "text";
+const isActionItemNote = (note: Topic["notes"][number]): note is ActionItemNote =>
+  note.type === "actionItem";
+
+const makeSpeakerReference = (person: Person): TextRun => {
+  return new TextRun({
+    text: [person.title, person.lastName].filter(Boolean).join(" "),
+    style: "SpeakerReference",
+  });
+};
+
+const sessionHeader = (metadata: SessionMetadata): Paragraph[] => {
+  const titleLine = `${metadata.title} - ${metadata.subtitle}: ${
+    metadata.location
+  }, ${metadata.startTime.toLocaleDateString(undefined, { timeZone: "UTC" })}`;
+  return [
+    new Paragraph({
+      children: [new TextRun(metadata.organization)],
+      heading: HeadingLevel.HEADING_1,
+    }),
+    new Paragraph({
+      children: [new TextRun({ text: titleLine, bold: true })],
+      heading: HeadingLevel.HEADING_2,
+    }),
+    new Paragraph({
+      children: [
+        new TextRun({ text: "Minutes: ", bold: true }),
+        new TextRun({ text: "DRAFT", style: "MinuteStateDraft" }),
+      ],
+      heading: HeadingLevel.HEADING_2,
+    }),
+  ];
+};
+
+const makeAttendanceLine = (name: string, people: Person[]): Paragraph => {
+  return new Paragraph({
+    children: [
+      new TextRun({ text: `${name}: `, bold: true }),
+      new TextRun(people.map((p) => p.lastName).join(", ")),
+    ],
+  });
+};
+
+const attendanceSection = (metadata: SessionMetadata): Paragraph[] => {
+  return [
+    makeAttendanceLine("Members in attendance", metadata.membersPresent),
+    makeAttendanceLine("Members absent", metadata.membersAbsent),
+    makeAttendanceLine("Administration", metadata.administrationPresent),
+    makeAttendanceLine("Others referenced", metadata.othersReferenced),
+  ];
+};
+
+const makeMonthTableRow = (monthEntry: CalendarMonthEntry): TableRow => {
+  return new TableRow({
+    children: [
+      new TableCell({
+        children: [new Paragraph(monthEntry.month)],
+        width: {
+          size: 15,
+          type: WidthType.PERCENTAGE,
+        },
+        margins: CalendarCellMargins,
+      }),
+      new TableCell({
+        children: monthEntry.items.map((item) => {
+          return new Paragraph({
+            children: [
+              new TextRun({
+                text: item.text,
+                strike: item.completed,
+              }),
+            ],
+          });
+        }),
+        width: {
+          size: 85,
+          type: WidthType.PERCENTAGE,
+        },
+        margins: CalendarCellMargins,
+      }),
+    ],
+  });
+};
+
+const makeCalendar = (calendar: Calendar): (Paragraph | Table)[] => {
+  if (calendar.length === 0) {
+    return [];
+  }
+  return [
+    new Paragraph({
+      children: [new TextRun("Board Calendar Items")],
+      style: "CalendarHeader",
+    }),
+    new Table({
+      rows: calendar.map(makeMonthTableRow),
+      width: {
+        size: 100,
+        type: WidthType.PERCENTAGE,
+      },
+    }),
+  ];
+};
+
+const makeCallToOrderParagraph = (session: Session): Paragraph[] => {
+  const actualStartTime = session.topics[0]?.startTime ?? session.metadata.startTime;
+  const formattedStartTime = actualStartTime.toLocaleTimeString(undefined, {
+    timeStyle: "short",
+    timeZone: "UTC",
+  });
+  const locationTextRun = new TextRun({
+    text: `The meeting was held at the ${session.metadata.location}. `,
+  });
+  const paragraphTitle = new Paragraph({
+    children: [
+      new TextRun({
+        text: session.metadata.subtitle,
+      }),
+    ],
+    heading: HeadingLevel.HEADING_1,
+  });
+  const paragraphText = session.metadata.caller
+    ? new Paragraph({
+        children: [
+          new TextRun({
+            text: `The meeting was called by ${session.metadata.caller.role}. `,
+          }),
+          locationTextRun,
+          makeSpeakerReference(session.metadata.caller.person),
+          new TextRun({
+            text: ` called the session to order at ${formattedStartTime}.`,
+          }),
+        ],
+      })
+    : new Paragraph({
+        children: [
+          locationTextRun,
+          new TextRun({
+            text: `The session was called to order at ${formattedStartTime}.`,
+          }),
+        ],
+      });
+
+  return [paragraphTitle, paragraphText];
+};
+
+const makeTopicHeader = (topic: Topic): Table => {
+  const cells: TableCell[] = [
+    new TableCell({
+      children: [
+        new Paragraph(
+          topic.startTime.toLocaleTimeString(undefined, {
+            timeStyle: "short",
+            timeZone: "UTC",
+          })
+        ),
+      ],
+      shading: TopicHeaderCellShading,
+      width: {
+        size: 15,
+        type: WidthType.PERCENTAGE,
+      },
+      margins: TopicHeaderCellMargins,
+    }),
+  ];
+  if (topic.durationMinutes) {
+    cells.push(
+      new TableCell({
+        children: [new Paragraph(topic.durationMinutes.toString())],
+        shading: TopicHeaderCellShading,
+        width: {
+          size: 10,
+          type: WidthType.PERCENTAGE,
+        },
+        margins: TopicHeaderCellMargins,
+      })
+    );
+  }
+  cells.push(
+    new TableCell({
+      children: [new Paragraph(topic.title)],
+      shading: TopicHeaderCellShading,
+      margins: TopicHeaderCellMargins,
+    })
+  );
+  return new Table({
+    rows: [
+      new TableRow({
+        children: cells,
+      }),
+    ],
+    width: {
+      size: 100,
+      type: WidthType.PERCENTAGE,
+    },
+  });
+};
+
+const makeTextNoteParagraphs = (note: TextNote): Paragraph[] => [
+  new Paragraph({
+    children: [new TextRun(note.text)],
+    style: "NoteFinalLine",
+  }),
+];
+
+type ActionItemNoteOrPastActionItem = {
+  assignee: Person;
+  text: string;
+  dueDate: Date;
+  completed?: boolean;
+};
+const makeActionItemTextRuns = (
+  actionItem: ActionItemNoteOrPastActionItem,
+  showStatus: boolean
+): TextRun[] => {
+  const textRuns = [
+    new TextRun({
+      text: "Action item: ",
+      style: "ActionItemPrefix",
+    }),
+    makeSpeakerReference(actionItem.assignee),
+    new TextRun({
+      text: ` to ${actionItem.text} by ${actionItem.dueDate.toLocaleDateString(
+        "en-US",
+        { dateStyle: "short", timeZone: "UTC" }
+      )}.`,
+    }),
+  ];
+
+  if (showStatus) {
+    if (actionItem.completed === false) {
+      textRuns.push(
+        new TextRun({
+          text: " (Carried forward)",
+          style: "ActionItemCarried",
+        })
+      );
+    } else if (actionItem.completed === true) {
+      textRuns.push(
+        new TextRun({
+          text: " (Done)",
+          style: "ActionItemDone",
+        })
+      );
+    } else {
+      textRuns.push(
+        new TextRun({
+          text: " (Added)",
+          style: "ActionItemAdded",
+        })
+      );
+    }
+  }
+  return textRuns;
+};
+
+const makeActionItemParagraphs = (note: ActionItemNote): Paragraph[] => [
+  new Paragraph({
+    children: makeActionItemTextRuns(note, false),
+    style: "NoteFinalLine",
+  }),
+];
+
+const makeMoverParagraph = (note: MotionNote): Paragraph =>
+  new Paragraph({
+    children: [
+      makeSpeakerReference(note.mover),
+      new TextRun({
+        text: ` moved ${note.text}`,
+      }),
+    ],
+    style: "MotionInternal",
+  });
+
+const makeSeconderParagraph = (note: MotionNote): Paragraph =>
+  new Paragraph({
+    children: [
+      makeSpeakerReference(note.seconder as Person),
+      new TextRun({
+        text: " seconded.",
+      }),
+    ],
+    style: "MotionInternal",
+  });
+
+const makeVoteParagraph = (note: MotionNote): Paragraph => {
+  const voteTallies = [];
+  if (note.inFavorCount) {
+    voteTallies.push(`${note.inFavorCount} in favor`);
+  }
+  if (note.opposedCount) {
+    voteTallies.push(`${note.opposedCount} opposed`);
+  }
+  if (note.abstainedCount) {
+    voteTallies.push(`${note.abstainedCount} abstained`);
+  }
+  return new Paragraph({
+    children: [
+      new TextRun({
+        text: "Vote:",
+        style: "MotionVotePrefix",
+      }),
+      new TextRun({
+        text: ` ${voteTallies.join(", ")}`,
+      }),
+    ],
+    style: "MotionInternal",
+  });
+};
+
+const makeOutcomeParagraph = (note: MotionNote): Paragraph => {
+  let outcomeText: string;
+  switch (note.outcome) {
+    case "active":
+      outcomeText = "Motion is under discussion.";
+      break;
+    case "passed":
+      outcomeText = "Motion passes.";
+      break;
+    case "failed":
+      outcomeText = "Motion fails.";
+      break;
+    case "withdrawn":
+      outcomeText = "Motion is withdrawn.";
+      break;
+    case "tabled":
+      outcomeText = "Motion is tabled.";
+      break;
+  }
+  return new Paragraph({
+    children: [
+      new TextRun({
+        text: outcomeText,
+      }),
+    ],
+    style: "MotionOutcome",
+  });
+};
+
+const makeMotionParagraphs = (note: MotionNote): Paragraph[] => {
+  const motionParagraphs: Paragraph[] = [];
+  motionParagraphs.push(makeMoverParagraph(note));
+  if (note.seconder) {
+    motionParagraphs.push(makeSeconderParagraph(note));
+  }
+  if (note.outcome === "failed" || note.outcome === "passed") {
+    motionParagraphs.push(makeVoteParagraph(note));
+  }
+  motionParagraphs.push(makeOutcomeParagraph(note));
+  return motionParagraphs;
+};
+
+const makeTopicBody = (topic: Topic): Paragraph[] => {
+  const noteParagraphs = topic.notes.flatMap((note) => {
+    if (isTextNote(note)) {
+      return makeTextNoteParagraphs(note);
+    } else if (isActionItemNote(note)) {
+      return makeActionItemParagraphs(note);
+    } else {
+      return makeMotionParagraphs(note);
+    }
+  });
+  if (noteParagraphs.length === 0) {
+    return [emptyLine()];
+  } else {
+    return noteParagraphs;
+  }
+};
+
+const makeCommitteeBulletPoint = (committee: Committee): Paragraph => {
+  return new Paragraph({
+    children: [new TextRun(`${committee.name} (${committee.type})`)],
+    bullet: {
+      level: 0,
+    },
+  });
+};
+
+const makeCommitteesSection = (
+  committees: Committee[],
+  committeeDocUrl?: string
+): Paragraph[] => {
+  const headerChildren: TextRun[] = [new TextRun("Active Committees: ")];
+  if (committeeDocUrl) {
+    headerChildren.push(
+      new TextRun({ text: "(Committees.docx)", style: "Hyperlink" })
+    );
+  }
+  return [
+    new Paragraph({
+      children: headerChildren,
+      style: "CommitteeHeader",
+    }),
+    ...committees.map(makeCommitteeBulletPoint),
+  ];
+};
+
+const makeListedActionItemBulletPoint = (
+  actionItem: ActionItemNote | PastActionItem
+): Paragraph => {
+  return new Paragraph({
+    children: makeActionItemTextRuns(actionItem, true),
+    bullet: {
+      level: 0,
+    },
+  });
+};
+
+const makeListedActionItemParagraphs = (
+  topics: Topic[],
+  pastActionItems: PastActionItem[]
+): Paragraph[] => {
+  const sessionActionItems = topics.flatMap((topic) =>
+    topic.notes.filter(isActionItemNote)
+  );
+  const allActionItems = [...sessionActionItems, ...pastActionItems].sort(
+    (a, b) => a.dueDate.getTime() - b.dueDate.getTime()
+  );
+  return [
+    new Paragraph({
+      children: [
+        new TextRun({ text: "Action Items:", style: "ActionItemHeader" }),
+        new TextRun(" (New and carried forward from previous meetings)"),
+      ],
+    }),
+    ...allActionItems.map(makeListedActionItemBulletPoint),
+  ];
+};
+
+const emptyLine = () => new Paragraph({ children: [new TextRun("")] });
+
+export const exportSessionToDocx: (session: Session) => Promise<Blob> = (
+  session
+) => {
+  const doc = new Document({
+    sections: [
+      {
+        properties: {},
+        children: [
+          ...sessionHeader(session.metadata),
+          emptyLine(),
+          ...attendanceSection(session.metadata),
+          ...makeCallToOrderParagraph(session),
+          ...makeCalendar(session.calendar),
+          emptyLine(),
+          ...session.topics.flatMap((topic) => [
+            makeTopicHeader(topic),
+            ...makeTopicBody(topic),
+          ]),
+          ...makeCommitteesSection(
+            session.committees,
+            session.metadata.committeeDocUrl
+          ),
+          emptyLine(),
+          ...makeListedActionItemParagraphs(
+            session.topics,
+            session.pastActionItems
+          ),
+        ],
+      },
+    ],
+    styles: Styles,
+  });
+  return Packer.toBlob(doc);
+};

--- a/src/docx/doc.ts
+++ b/src/docx/doc.ts
@@ -88,7 +88,6 @@ const attendanceSection = (metadata: SessionMetadata): Paragraph[] => {
     makeAttendanceLine("Members in attendance", metadata.membersPresent),
     makeAttendanceLine("Members absent", metadata.membersAbsent),
     makeAttendanceLine("Administration", metadata.administrationPresent),
-    makeAttendanceLine("Others referenced", metadata.othersReferenced),
   ];
 };
 

--- a/src/docx/mapMeetingToSession.ts
+++ b/src/docx/mapMeetingToSession.ts
@@ -1,0 +1,122 @@
+// Adapts prepare-to-board's Meeting/Organization/BoardMember data into the
+// local Session shape that doc.ts knows how to render. Several
+// SessionMetadata fields (location, title, subtitle, caller, attendance)
+// have no equivalent in our data model yet - they're tracked as follow-up
+// issues (#32-#36) and left as empty placeholders here, matching the
+// milestone's explicit scope.
+import {
+  BoardMember,
+  Meeting,
+  MotionNote as SourceMotionNote,
+  Note as SourceNote,
+  Organization,
+} from "../schema";
+import {
+  ActionItemNote,
+  MotionNote,
+  Note,
+  Person,
+  Session,
+  TextNote,
+  Topic,
+} from "./model";
+
+const personFromBoardMemberOrName = (
+  member: BoardMember | undefined,
+  fallbackName?: string
+): Person => ({
+  title: "",
+  firstName: "",
+  lastName: member?.name ?? fallbackName ?? "Unknown",
+});
+
+const mapMotionOutcome = (
+  status: SourceMotionNote["status"]
+): MotionNote["outcome"] => {
+  switch (status) {
+    case "proposed":
+    case "under_discussion":
+      return "active";
+    case "passed":
+      return "passed";
+    case "failed":
+      return "failed";
+    case "tabled":
+      return "tabled";
+  }
+};
+
+const mapNote = (note: SourceNote): Note => {
+  if (note.type === "text") {
+    const textNote: TextNote = { type: "text", text: note.text };
+    return textNote;
+  }
+  if (note.type === "action_item") {
+    const actionItemNote: ActionItemNote = {
+      type: "actionItem",
+      text: note.text,
+      assignee: personFromBoardMemberOrName(note.assignee),
+      dueDate: note.dueDate !== undefined ? new Date(note.dueDate) : new Date(),
+      // undefined (not false) for open items: these come from the current
+      // meeting's own topics, not a carried-forward past-action-items list
+      // (which prepare-to-board doesn't track yet), so "(Added)" is the
+      // correct marker rather than "(Carried forward)".
+      completed: note.completedOn !== undefined ? true : undefined,
+    };
+    return actionItemNote;
+  }
+  const motionNote: MotionNote = {
+    type: "motion",
+    text: note.text,
+    mover: personFromBoardMemberOrName(note.moverMember, note.mover),
+    seconder: note.seconder
+      ? personFromBoardMemberOrName(note.seconderMember, note.seconder)
+      : undefined,
+    inFavorCount: note.votesFor,
+    opposedCount: note.votesAgainst,
+    abstainedCount: note.votesAbstain,
+    outcome: mapMotionOutcome(note.status),
+  };
+  return motionNote;
+};
+
+export const mapMeetingToSession = (
+  meeting: Meeting,
+  organization: Organization
+): Session => {
+  const completedMinutes = (meeting.minutes ?? []).filter((m) => m !== null);
+  const startTime = meeting.liveStartTime ?? meeting.date;
+
+  let topicCursor = new Date(startTime);
+  const topics: Topic[] = completedMinutes.map((minute) => {
+    const topicStart = new Date(topicCursor);
+    topicCursor = new Date(
+      topicCursor.getTime() + minute.durationMinutes * 60 * 1000
+    );
+    const notes = (minute.notes ?? []).filter((n) => n !== null).map(mapNote);
+    return {
+      title: minute.topic?.title ?? "(untitled)",
+      notes,
+      startTime: topicStart,
+      durationMinutes: minute.durationMinutes,
+    };
+  });
+
+  return {
+    metadata: {
+      membersPresent: [],
+      membersAbsent: [],
+      administrationPresent: [],
+      othersReferenced: [],
+      location: "",
+      startTime,
+      organization: organization.name,
+      title: "Board Meeting",
+      subtitle: "Regular Session",
+    },
+    calendar: [],
+    topics,
+    committees: [],
+    pastActionItems: [],
+  };
+};

--- a/src/docx/mapMeetingToSession.ts
+++ b/src/docx/mapMeetingToSession.ts
@@ -107,7 +107,6 @@ export const mapMeetingToSession = (
       membersPresent: [],
       membersAbsent: [],
       administrationPresent: [],
-      othersReferenced: [],
       location: "",
       startTime,
       organization: organization.name,

--- a/src/docx/model.ts
+++ b/src/docx/model.ts
@@ -16,7 +16,6 @@ export type SessionMetadata = {
   membersPresent: Person[];
   membersAbsent: Person[];
   administrationPresent: Person[];
-  othersReferenced: Person[];
   location: string;
   startTime: Date;
   organization: string;

--- a/src/docx/model.ts
+++ b/src/docx/model.ts
@@ -1,0 +1,125 @@
+// Local re-statement of the parts of butaud/minutes-taker's `minutes-model`
+// package that doc.ts/style.ts depend on, so exportSessionToDocx can be
+// ported without pulling in that whole app. Kept deliberately identical in
+// shape to make future upstream comparisons easy, with two intentional
+// deviations noted inline where our data model can't fill them exactly.
+
+export type Session = {
+  metadata: SessionMetadata;
+  calendar: Calendar;
+  topics: Topic[];
+  committees: Committee[];
+  pastActionItems: PastActionItem[];
+};
+
+export type SessionMetadata = {
+  membersPresent: Person[];
+  membersAbsent: Person[];
+  administrationPresent: Person[];
+  othersReferenced: Person[];
+  location: string;
+  startTime: Date;
+  organization: string;
+  title: string;
+  subtitle: string;
+  caller?: Caller;
+  committeeDocUrl?: string;
+};
+
+export type CommitteeType = "Board" | "Headmaster";
+
+export type Committee = {
+  name: string;
+  type: CommitteeType;
+};
+
+export type PastActionItem = {
+  text: string;
+  assignee: Person;
+  dueDate: Date;
+  completed: boolean;
+};
+
+export type CalendarMonth =
+  | "January"
+  | "February"
+  | "March"
+  | "April"
+  | "May"
+  | "June"
+  | "July"
+  | "August"
+  | "September"
+  | "October"
+  | "November"
+  | "December";
+
+export type Calendar = CalendarMonthEntry[];
+
+export type CalendarMonthEntry = {
+  month: CalendarMonth;
+  items: CalendarItem[];
+};
+
+export type CalendarItem = {
+  text: string;
+  completed: boolean;
+};
+
+// minutes-taker's Person is { title: "Mr."|"Mrs."|"Miss", firstName, lastName }.
+// prepare-to-board's BoardMember only has a single `name` string, so we
+// deviate here: title/firstName are always "" and the full name goes in
+// lastName. See mapMeetingToSession.ts for the mapping and PR notes for the
+// known cosmetic effect (speaker references read as the full name rather
+// than an honorific + last name).
+export type Person = {
+  title: string;
+  firstName: string;
+  lastName: string;
+};
+
+export type Caller = {
+  person: Person;
+  role: string;
+};
+
+export type Topic = {
+  title: string;
+  notes: Note[];
+  startTime: Date;
+  durationMinutes?: number;
+  leader?: Person;
+};
+
+export type Note = TextNote | ActionItemNote | MotionNote;
+
+export type TextNote = {
+  type: "text";
+  text: string;
+};
+
+export type ActionItemNote = {
+  type: "actionItem";
+  text: string;
+  assignee: Person;
+  dueDate: Date;
+  // Deviation: not present in minutes-taker's ActionItemNote (which only
+  // tracks completion via the separate PastActionItem list). We do track
+  // completion per-item, so it's carried through here to get accurate
+  // "(Done)" markers in the listed action items section.
+  completed?: boolean;
+};
+
+export type MotionNote = {
+  type: "motion";
+  text: string;
+  mover: Person;
+  // Deviation: minutes-taker requires a seconder; prepare-to-board's motion
+  // form treats it as optional, so this stays optional here too. doc.ts's
+  // seconder paragraph is skipped when absent.
+  seconder?: Person;
+  inFavorCount?: number;
+  opposedCount?: number;
+  abstainedCount?: number;
+  outcome: "passed" | "failed" | "tabled" | "withdrawn" | "active";
+};

--- a/src/docx/style.ts
+++ b/src/docx/style.ts
@@ -1,0 +1,195 @@
+// Ported directly from butaud/minutes-taker's src/fs/style.ts, unchanged.
+// Keeping this byte-for-byte identical is what makes the exported .docx
+// look like minutes-taker's output.
+import {
+  IShadingAttributesProperties,
+  IStylesOptions,
+  ITableCellOptions,
+  WidthType,
+} from "docx";
+
+export const Styles: IStylesOptions = {
+  default: {
+    heading1: {
+      run: {
+        size: 32,
+        bold: true,
+        color: "000000",
+        font: "Calibri Bold",
+      },
+      paragraph: {
+        spacing: {
+          after: 120,
+        },
+      },
+    },
+    heading2: {
+      run: {
+        size: 24,
+        bold: true,
+        color: "000000",
+        font: "Calibri Bold",
+      },
+    },
+    document: {
+      run: {
+        size: 22,
+        color: "000000",
+        font: "Calibri",
+      },
+    },
+  },
+  paragraphStyles: [
+    {
+      id: "CalendarHeader",
+      name: "Calendar Header",
+      run: {
+        bold: true,
+      },
+      paragraph: {
+        spacing: {
+          before: 200,
+        },
+      },
+    },
+    {
+      id: "MotionInternal",
+      name: "Motion Internal Line",
+      paragraph: {
+        spacing: {
+          afterAutoSpacing: false,
+        },
+      },
+    },
+    {
+      id: "NoteFinalLine",
+      name: "Note Final Line",
+      basedOn: "Normal",
+      paragraph: {
+        spacing: {
+          after: 200,
+        },
+      },
+    },
+    {
+      id: "MotionOutcome",
+      name: "Motion Outcome Line",
+      basedOn: "NoteFinalLine",
+      run: {
+        bold: true,
+      },
+    },
+    {
+      id: "CommitteeHeader",
+      name: "Committee Header",
+      basedOn: "Normal",
+      run: {
+        bold: true,
+        underline: {
+          color: "000000",
+        },
+      },
+    },
+  ],
+  characterStyles: [
+    {
+      id: "MinuteStateDraft",
+      name: "Minute State Draft",
+      basedOn: "Normal",
+      quickFormat: true,
+      run: {
+        color: "c0504d",
+      },
+    },
+    {
+      id: "SpeakerReference",
+      name: "Speaker Reference",
+      basedOn: "Normal",
+      quickFormat: true,
+      run: {
+        color: "4f81bd",
+        bold: true,
+      },
+    },
+    {
+      id: "ActionItemPrefix",
+      name: "Action Item Prefix",
+      basedOn: "Normal",
+      quickFormat: true,
+      run: {
+        italics: true,
+      },
+    },
+    {
+      id: "ActionItemCarried",
+      name: "Action Item Carried",
+      basedOn: "Normal",
+      quickFormat: true,
+      run: {
+        bold: true,
+        color: "000000",
+      },
+    },
+    {
+      id: "ActionItemDone",
+      name: "Action Item Done",
+      basedOn: "Normal",
+      quickFormat: true,
+      run: {
+        bold: true,
+        color: "9bbb59",
+      },
+    },
+    {
+      id: "ActionItemAdded",
+      name: "Action Item Added",
+      basedOn: "Normal",
+      quickFormat: true,
+      run: {
+        bold: true,
+        color: "4f81bd",
+      },
+    },
+    {
+      id: "MotionVotePrefix",
+      name: "Motion Vote Prefix",
+      basedOn: "Normal",
+      quickFormat: true,
+      run: {
+        bold: true,
+      },
+    },
+    {
+      id: "ActionItemHeader",
+      name: "Action Item Header",
+      basedOn: "Normal",
+      quickFormat: true,
+      run: {
+        bold: true,
+        underline: {
+          color: "000000",
+        },
+      },
+    },
+  ],
+};
+
+export const TopicHeaderCellShading: IShadingAttributesProperties = {
+  fill: "b8cce4",
+};
+
+export const TopicHeaderCellMargins: ITableCellOptions["margins"] = {
+  marginUnitType: WidthType.DXA,
+  top: 100,
+  bottom: 100,
+  left: 200,
+  right: 200,
+};
+
+export const CalendarCellMargins: ITableCellOptions["margins"] = {
+  marginUnitType: WidthType.DXA,
+  top: 10,
+  bottom: 10,
+  left: 75,
+  right: 75,
+};

--- a/src/views/meeting/MeetingMinutes.css
+++ b/src/views/meeting/MeetingMinutes.css
@@ -52,6 +52,18 @@
   margin: 0;
 }
 
+.minutes-completed-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.minutes-completed-header h2 {
+  margin: 0 0 4px 0;
+}
+
 .minutes-section {
   position: relative;
   z-index: 1;
@@ -139,6 +151,52 @@
   font-weight: 700;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.integrity-banner {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 14px;
+  padding: 10px 14px;
+  background: var(--danger-color-subtle);
+  border: 1px solid var(--danger-color);
+  border-radius: 8px;
+}
+
+.integrity-banner-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.integrity-banner-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--danger-color-strong);
+}
+
+.integrity-banner-group ul {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.integrity-issue-link {
+  display: inline;
+  padding: 0;
+  background: none;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.integrity-issue-link:hover {
+  color: var(--danger-color-strong);
 }
 
 .minutes-topic-tray {
@@ -609,6 +667,34 @@
 
 .minutes-day-view-range {
   display: none;
+}
+
+.minutes-day-view-notes-count {
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  padding: 1px 6px;
+  font-size: 0.62rem;
+  font-weight: 700;
+  line-height: 1.4;
+  letter-spacing: 0.02em;
+  color: var(--primary-color);
+  background: var(--primary-color-subtle);
+  border-radius: 8px;
+  white-space: nowrap;
+}
+
+.minutes-day-view-notes-count.is-empty {
+  color: var(--muted-color, var(--primary-color-light));
+  background: var(--border-color-subtle);
+  font-weight: 500;
+  opacity: 0.85;
+}
+
+.meeting-minutes .minutes-day-view-event.is-meeting-active .minutes-day-view-notes-count {
+  color: var(--primary-color);
+  background: rgba(255, 255, 255, 0.85);
+  opacity: 1;
 }
 
 .minutes-day-view-actions {

--- a/src/views/meeting/MeetingMinutes.tsx
+++ b/src/views/meeting/MeetingMinutes.tsx
@@ -15,7 +15,9 @@ import { api } from "../../convexClient";
 
 import "react-datepicker/dist/react-datepicker.css";
 import "./MeetingMinutes.css";
-import { NoteDisplay } from "../../ui/NoteDisplay";
+import { NoteDisplay, type ActionItemCompletionControl } from "../../ui/NoteDisplay";
+import { exportSessionToDocx } from "../../docx/doc";
+import { mapMeetingToSession } from "../../docx/mapMeetingToSession";
 
 const formatDuration = (totalSeconds: number): string => {
   const sign = totalSeconds < 0 ? "-" : "";
@@ -403,6 +405,98 @@ const MotionForm = ({
   );
 };
 
+// --- Integrity checks ---
+
+type IntegrityIssue = {
+  topicId: string;
+  topicTitle: string;
+  text: string;
+};
+
+type NotesByTopic = {
+  topicId: string;
+  topicTitle: string;
+  notes: Note[];
+};
+
+const UNRESOLVED_MOTION_STATUSES = new Set(["proposed", "under_discussion"]);
+
+const collectIntegrityIssues = (
+  groups: NotesByTopic[]
+): { unresolvedMotions: IntegrityIssue[]; unassignedActionItems: IntegrityIssue[] } => {
+  const unresolvedMotions: IntegrityIssue[] = [];
+  const unassignedActionItems: IntegrityIssue[] = [];
+  for (const group of groups) {
+    for (const note of group.notes) {
+      if (note.type === "motion" && UNRESOLVED_MOTION_STATUSES.has(note.status)) {
+        unresolvedMotions.push({
+          topicId: group.topicId,
+          topicTitle: group.topicTitle,
+          text: note.text,
+        });
+      }
+      if (note.type === "action_item" && !note.assignee) {
+        unassignedActionItems.push({
+          topicId: group.topicId,
+          topicTitle: group.topicTitle,
+          text: note.text,
+        });
+      }
+    }
+  }
+  return { unresolvedMotions, unassignedActionItems };
+};
+
+const IntegrityBanner = ({
+  unresolvedMotions,
+  unassignedActionItems,
+  onJump,
+}: {
+  unresolvedMotions: IntegrityIssue[];
+  unassignedActionItems: IntegrityIssue[];
+  onJump?: (topicId: string) => void;
+}) => {
+  if (unresolvedMotions.length === 0 && unassignedActionItems.length === 0) return null;
+
+  const renderIssue = (issue: IntegrityIssue, i: number) =>
+    onJump ? (
+      <li key={i}>
+        <button className="integrity-issue-link" onClick={() => onJump(issue.topicId)}>
+          <strong>{issue.topicTitle}:</strong> {issue.text}
+        </button>
+      </li>
+    ) : (
+      <li key={i}>
+        <a className="integrity-issue-link" href={`#minute-${issue.topicId}`}>
+          <strong>{issue.topicTitle}:</strong> {issue.text}
+        </a>
+      </li>
+    );
+
+  return (
+    <div className="integrity-banner">
+      {unresolvedMotions.length > 0 && (
+        <div className="integrity-banner-group">
+          <span className="integrity-banner-label">
+            {unresolvedMotions.length} motion{unresolvedMotions.length !== 1 ? "s" : ""} still
+            unresolved
+          </span>
+          <ul>{unresolvedMotions.map(renderIssue)}</ul>
+        </div>
+      )}
+      {unassignedActionItems.length > 0 && (
+        <div className="integrity-banner-group">
+          <span className="integrity-banner-label">
+            {unassignedActionItems.length} action item
+            {unassignedActionItems.length !== 1 ? "s" : ""} with no assignee
+          </span>
+          <ul>{unassignedActionItems.map(renderIssue)}</ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
 const toStoredNote = (note: PendingNote) => {
   if (note.type === "action_item") {
     return {
@@ -441,6 +535,7 @@ type EditableNoteProps = {
   onStopEdit: () => void;
   onUpdate: (note: PendingNote) => void;
   onDelete: () => void;
+  completion?: ActionItemCompletionControl;
 };
 
 const EditableNote = ({
@@ -451,6 +546,7 @@ const EditableNote = ({
   onStopEdit,
   onUpdate,
   onDelete,
+  completion,
 }: EditableNoteProps) => {
   if (isEditing) {
     const handleSave = (updatedNote: PendingNote) => {
@@ -492,7 +588,7 @@ const EditableNote = ({
 
   return (
     <div className="minutes-note-item">
-      <NoteDisplay note={note} />
+      <NoteDisplay note={note} completion={completion} />
       <button
         className="note-edit-btn"
         title="Edit note"
@@ -519,14 +615,24 @@ interface CompletedMinuteNotesProps {
   minute: NonNullable<NonNullable<ReturnType<typeof useMeeting>["minutes"]>[number]>;
   meeting: ReturnType<typeof useMeeting>;
   members: BoardMember[];
+  /** Whether the current viewer can toggle completion on any action item, not just their own. */
+  canToggleAny: boolean;
+  myBoardMemberId?: string;
 }
 
-const CompletedMinuteNotes = ({ minute, meeting, members }: CompletedMinuteNotesProps) => {
+const CompletedMinuteNotes = ({
+  minute,
+  meeting,
+  members,
+  canToggleAny,
+  myBoardMemberId,
+}: CompletedMinuteNotesProps) => {
   const [noteFormType, setNoteFormType] = useState<"text" | "action_item" | "motion" | null>(null);
   const [editingNoteId, setEditingNoteId] = useState<string | null>(null);
   const addMinuteNote = useMutation(api.app.addMinuteNote);
   const updateMinuteNote = useMutation(api.app.updateMinuteNote);
   const removeMinuteNote = useMutation(api.app.removeMinuteNote);
+  const setActionItemCompletedOn = useMutation(api.app.setActionItemCompletedOn);
 
   const addNoteToMinute = (pn: PendingNote) => {
     void addMinuteNote({
@@ -558,6 +664,22 @@ const CompletedMinuteNotes = ({ minute, meeting, members }: CompletedMinuteNotes
               noteId: note.id,
               note: toStoredNote(updatedNote),
             })
+          }
+          completion={
+            note.type === "action_item"
+              ? {
+                  canToggle:
+                    canToggleAny ||
+                    (note.assignee?.id !== undefined && note.assignee.id === myBoardMemberId),
+                  onToggle: (completedOn) =>
+                    void setActionItemCompletedOn({
+                      meetingId: meeting.id,
+                      minuteId: minute.id,
+                      noteId: note.id,
+                      completedOn,
+                    }),
+                }
+              : undefined
           }
           onDelete={() => {
             void removeMinuteNote({
@@ -611,18 +733,64 @@ const PostMeetingMinutes = () => {
     .filter((t) => t !== null)
     .filter((t) => !coveredTopicIds.has(t.id));
 
+  const organization = me.root.selectedOrganization;
+  const [isExporting, setIsExporting] = useState(false);
+  const handleExportDocx = async () => {
+    if (!organization) return;
+    setIsExporting(true);
+    try {
+      const session = mapMeetingToSession(meeting, organization);
+      const blob = await exportSessionToDocx(session);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      const dateStr = meeting.date.toISOString().slice(0, 10);
+      a.download = `Board Meeting Minutes - ${dateStr}.docx`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const integrityIssues = collectIntegrityIssues(
+    completedMinutes.map((minute) => ({
+      topicId: minute.topic?.id ?? minute.id,
+      topicTitle: minute.topic?.title ?? "(untitled)",
+      notes: minute.notes ? minute.notes.filter((n) => n !== null) : [],
+    }))
+  );
+
   // unplanned = live topics with no plannedTopic that have a minute
   return (
     <div className="meeting-minutes-completed">
-      <h2>Meeting Minutes</h2>
-      <p className="minutes-date">
-        {meeting.date.toLocaleDateString(undefined, {
-          weekday: "long",
-          year: "numeric",
-          month: "long",
-          day: "numeric",
-        })}
-      </p>
+      <div className="minutes-completed-header">
+        <div>
+          <h2>Meeting Minutes</h2>
+          <p className="minutes-date">
+            {meeting.date.toLocaleDateString(undefined, {
+              weekday: "long",
+              year: "numeric",
+              month: "long",
+              day: "numeric",
+            })}
+          </p>
+        </div>
+        <button
+          className="btn-secondary"
+          onClick={() => void handleExportDocx()}
+          disabled={isExporting || !organization}
+        >
+          {isExporting ? "Exporting…" : "Export as Word (.docx)"}
+        </button>
+      </div>
+
+      <IntegrityBanner
+        unresolvedMotions={integrityIssues.unresolvedMotions}
+        unassignedActionItems={integrityIssues.unassignedActionItems}
+      />
 
       <section className="minutes-section">
         <h3>Official Minutes</h3>
@@ -638,7 +806,7 @@ const PostMeetingMinutes = () => {
               const diff = planned !== undefined ? actual - planned : null;
               const notes = minute.notes ? minute.notes.filter((n) => n !== null) : [];
               return (
-                <li key={idx} className="minutes-item">
+                <li key={idx} id={`minute-${topic?.id ?? minute.id}`} className="minutes-item">
                   <div className="minutes-item-header">
                     <span className="minutes-item-title">
                       {topic?.title ?? "(unknown)"}
@@ -658,32 +826,41 @@ const PostMeetingMinutes = () => {
                   {topic?.outcome && (
                     <div className="minutes-item-notes">{topic.outcome}</div>
                   )}
-                  {notes.length > 0 && (
-                    <div className="minutes-item-structured-notes">
-                      {notes.map((note, ni) => (
-                        <NoteDisplay
-                          key={ni}
-                          note={note}
-                          completion={
-                            note.type === "action_item"
-                              ? {
-                                  canToggle:
-                                    Boolean(isOfficer) ||
-                                    (note.assignee?.id !== undefined &&
-                                      note.assignee.id === myBoardMemberId),
-                                  onToggle: (completedOn) =>
-                                    void setActionItemCompletedOn({
-                                      meetingId: meeting.id,
-                                      minuteId: minute.id,
-                                      noteId: note.id,
-                                      completedOn,
-                                    }),
-                                }
-                              : undefined
-                          }
-                        />
-                      ))}
-                    </div>
+                  {isOfficer ? (
+                    <CompletedMinuteNotes
+                      minute={minute}
+                      meeting={meeting}
+                      members={members}
+                      canToggleAny={Boolean(isOfficer)}
+                      myBoardMemberId={myBoardMemberId}
+                    />
+                  ) : (
+                    notes.length > 0 && (
+                      <div className="minutes-item-structured-notes">
+                        {notes.map((note, ni) => (
+                          <NoteDisplay
+                            key={ni}
+                            note={note}
+                            completion={
+                              note.type === "action_item"
+                                ? {
+                                    canToggle:
+                                      note.assignee?.id !== undefined &&
+                                      note.assignee.id === myBoardMemberId,
+                                    onToggle: (completedOn) =>
+                                      void setActionItemCompletedOn({
+                                        meetingId: meeting.id,
+                                        minuteId: minute.id,
+                                        noteId: note.id,
+                                        completedOn,
+                                      }),
+                                  }
+                                : undefined
+                            }
+                          />
+                        ))}
+                      </div>
+                    )
                   )}
                 </li>
               );
@@ -1009,6 +1186,8 @@ export const MeetingMinutes = () => {
   const isOfficer = me?.canWrite(meeting);
 
   const members = (me.root.selectedOrganization?.members ?? []).filter((m) => m !== null);
+  const myBoardMemberId = members.find((m) => m.accountId === me.id)?.id;
+  const setActionItemCompletedOn = useMutation(api.app.setActionItemCompletedOn);
 
   const liveStartTime = meeting.liveStartTime;
   const meetingActualStartTime = liveStartTime ?? meeting.date;
@@ -1595,6 +1774,16 @@ export const MeetingMinutes = () => {
     setIsEditingMeetingStartTime(false);
   };
 
+  const notesCountForAgendaItem = (item: AgendaMenuItem): number => {
+    if (item.kind === "completed") {
+      return (item.minute.notes ?? []).filter((n) => n !== null).length;
+    }
+    if (item.kind === "meeting-active") {
+      return (meeting.currentNotes ?? []).filter((n) => n !== null).length;
+    }
+    return 0;
+  };
+
   const renderTimelineButtonContent = (entry: AgendaTimelineEntry) => {
     const { item } = entry;
     const topic = item.topic;
@@ -1611,6 +1800,7 @@ export const MeetingMinutes = () => {
           : item.kind === "deferred"
             ? "Deferred"
             : "Projected";
+    const notesCount = notesCountForAgendaItem(item);
 
     return (
       <>
@@ -1627,6 +1817,12 @@ export const MeetingMinutes = () => {
         </span>
         <span className="minutes-day-view-range">
           {formatAgendaTime(entry.start)} - {formatAgendaTime(entry.end)}
+        </span>
+        <span
+          className={`minutes-day-view-notes-count${notesCount === 0 ? " is-empty" : ""}`}
+          title={notesCount === 0 ? "No notes yet" : `${notesCount} note${notesCount !== 1 ? "s" : ""}`}
+        >
+          {notesCount === 0 ? "No notes" : `${notesCount} note${notesCount !== 1 ? "s" : ""}`}
         </span>
       </>
     );
@@ -1760,6 +1956,23 @@ export const MeetingMinutes = () => {
     });
   };
 
+  const integrityIssues = collectIntegrityIssues([
+    ...completedMinutes.map((minute) => ({
+      topicId: minute.topic?.id ?? minute.id,
+      topicTitle: minute.topic?.title ?? "(untitled)",
+      notes: minute.notes ? minute.notes.filter((n) => n !== null) : [],
+    })),
+    ...(meetingActiveTopic
+      ? [
+          {
+            topicId: meetingActiveTopic.id,
+            topicTitle: meetingActiveTopic.title,
+            notes: (meeting.currentNotes ?? []).filter((n) => n !== null),
+          },
+        ]
+      : []),
+  ]);
+
   return (
     <div className="meeting-minutes" ref={minutesLayoutRef}>
       <svg
@@ -1781,6 +1994,11 @@ export const MeetingMinutes = () => {
         />
       </svg>
       <div className="minutes-topic-main">
+        <IntegrityBanner
+          unresolvedMotions={integrityIssues.unresolvedMotions}
+          unassignedActionItems={integrityIssues.unassignedActionItems}
+          onJump={(topicId) => handleSelectTopic(topicId, true)}
+        />
         {shouldShowActiveTopicBanner && meetingActiveTopic && (
           <button
             ref={activeBannerRef}
@@ -1916,7 +2134,13 @@ export const MeetingMinutes = () => {
             )}
 
             {selectedAgendaItem.kind === "completed" && (
-              <CompletedMinuteNotes minute={selectedAgendaItem.minute} meeting={meeting} members={members} />
+              <CompletedMinuteNotes
+                minute={selectedAgendaItem.minute}
+                meeting={meeting}
+                members={members}
+                canToggleAny={Boolean(isOfficer)}
+                myBoardMemberId={myBoardMemberId}
+              />
             )}
 
             {selectedAgendaItem.kind === "meeting-active" && (
@@ -1940,6 +2164,22 @@ export const MeetingMinutes = () => {
                         noteId: note.id,
                         note: toStoredNote(updatedNote),
                       })
+                    }
+                    completion={
+                      note.type === "action_item"
+                        ? {
+                            canToggle:
+                              Boolean(isOfficer) ||
+                              (note.assignee?.id !== undefined &&
+                                note.assignee.id === myBoardMemberId),
+                            onToggle: (completedOn) =>
+                              void setActionItemCompletedOn({
+                                meetingId: meeting.id,
+                                noteId: note.id,
+                                completedOn,
+                              }),
+                          }
+                        : undefined
                     }
                     onDelete={() => {
                       void removeCurrentNote({ meetingId: meeting.id, index: i });

--- a/yarn.lock
+++ b/yarn.lock
@@ -800,6 +800,13 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
+"@types/node@^20.3.1":
+  version "20.19.43"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.19.43.tgz#fcecf580ba42a0db55cf404c372c97973c376c97"
+  integrity sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==
+  dependencies:
+    undici-types "~6.21.0"
+
 "@types/node@^24.1.0":
   version "24.1.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-24.1.0.tgz#0993f7dc31ab5cc402d112315b463e383d68a49c"
@@ -1044,6 +1051,11 @@ cookie@^1.0.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.0.2.tgz#27360701532116bd3f1f9416929d176afe1e4610"
   integrity sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==
 
+core-util-is@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
+  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
+
 cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
@@ -1086,6 +1098,17 @@ dequal@2.0.3, dequal@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
+docx@8.2.1:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/docx/-/docx-8.2.1.tgz#fcfdf7eb999f3bfb481d73664ca067eb82ecd8d8"
+  integrity sha512-ccwgWWhDkAPN8+XP4C8NhsGvqrvPvecvxLlLAZz0tSMBi3+u4XJK/F+oMTjvbmrsj6nLmOVexG/Th5eBZbPskg==
+  dependencies:
+    "@types/node" "^20.3.1"
+    jszip "^3.10.1"
+    nanoid "^4.0.2"
+    xml "^1.0.1"
+    xml-js "^1.6.8"
 
 dotenv@^17.4.2:
   version "17.4.2"
@@ -1404,6 +1427,11 @@ ignore@^5.2.0, ignore@^5.3.1:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
+
 import-fresh@^3.2.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.1.tgz#9cecb56503c0ada1f2741dbbd6546e4b13b57ccf"
@@ -1416,6 +1444,11 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
+
+inherits@~2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 is-extglob@^2.1.1:
   version "2.1.1"
@@ -1433,6 +1466,11 @@ is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+isarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -1481,6 +1519,16 @@ json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
+jszip@^3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
+  integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==
+  dependencies:
+    lie "~3.3.0"
+    pako "~1.0.2"
+    readable-stream "~2.3.6"
+    setimmediate "^1.0.5"
+
 keyv@^4.5.4:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
@@ -1495,6 +1543,13 @@ levn@^0.4.1:
   dependencies:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
+
+lie@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
+  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
+  dependencies:
+    immediate "~3.0.5"
 
 locate-path@^6.0.0:
   version "6.0.0"
@@ -1552,6 +1607,11 @@ nanoid@^3.3.8:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
 
+nanoid@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-4.0.2.tgz#140b3c5003959adbebf521c170f282c5e7f9fb9e"
+  integrity sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -1587,6 +1647,11 @@ p-locate@^5.0.0:
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
+
+pako@~1.0.2:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -1647,6 +1712,11 @@ prettier@^3.0.0:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.8.3.tgz#560f2de55bf01b4c0503bc629d5df99b9a1d09b0"
   integrity sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==
+
+process-nextick-args@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
 punycode@^2.1.0:
   version "2.3.1"
@@ -1717,6 +1787,19 @@ react@^19.0.0:
   resolved "https://registry.yarnpkg.com/react/-/react-19.1.0.tgz#926864b6c48da7627f004795d6cce50e90793b75"
   integrity sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==
 
+readable-stream@~2.3.6:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
+  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
 redux@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-5.0.1.tgz#97fa26881ce5746500125585d5642c77b6e9447b"
@@ -1768,6 +1851,16 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+sax@^1.2.4:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.6.1.tgz#4c23cf608c0b693ab54b4b5888e92cfe977b9843"
+  integrity sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==
+
 scheduler@^0.26.0:
   version "0.26.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.26.0.tgz#4ce8a8c2a2095f13ea11bf9a445be50c555d6337"
@@ -1787,6 +1880,11 @@ set-cookie-parser@^2.6.0:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz#3016f150072202dfbe90fadee053573cc89d2943"
   integrity sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==
+
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  integrity sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -1809,6 +1907,13 @@ std-env@^3.7.0:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.8.1.tgz#2b81c631c62e3d0b964b87f099b8dcab6c9a5346"
   integrity sha512-vj5lIj3Mwf9D79hBkltk5qmkFI+biIKWS2IBxEyEU3AX1tUf7AoL8nSazCOiiqQsGKIq01SClsKEzweu34uwvA==
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
 
 strip-json-comments@^3.1.1:
   version "3.1.1"
@@ -1878,6 +1983,11 @@ typescript@~5.7.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
   integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
 
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+
 undici-types@~7.8.0:
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.8.0.tgz#de00b85b710c54122e44fbfd911f8d70174cd294"
@@ -1902,6 +2012,11 @@ use-sync-external-store@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz#adbc795d8eeb47029963016cefdf89dc799fcebc"
   integrity sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==
+
+util-deprecate@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 vite@^6.2.0:
   version "6.2.3"
@@ -1930,6 +2045,18 @@ ws@8.18.0:
   version "8.18.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
   integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+
+xml-js@^1.6.8:
+  version "1.6.11"
+  resolved "https://registry.yarnpkg.com/xml-js/-/xml-js-1.6.11.tgz#927d2f6947f7f1c19a316dd8eea3614e8b18f8e9"
+  integrity sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==
+  dependencies:
+    sax "^1.2.4"
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==
 
 yallist@^3.0.2:
   version "3.1.1"


### PR DESCRIPTION
## Summary

Implements the **Meeting Minutes: Always-Editable, DOCX Export & Integrity Checks** milestone — resolves #27, #28, #22, #26.

- **Finalized minutes are no longer read-only.** Officers/writers can add, edit, and remove text/action-item/motion notes on a completed meeting the same way they could while it was live — the "instant finalize with no proofread window" problem (#27) is now solved by just letting corrections happen after the fact instead of adding a separate review-gate workflow.
- **Export as Word (.docx)** — a button on the finalized minutes page generates and downloads a `.docx` file client-side, ported from `butaud/minutes-taker`'s document generator (#28).
- **Integrity-check banner** — surfaces unresolved motions (status still "Proposed"/"Under Discussion") and action items with no assignee, on both the live and finalized minutes views, with a jump-to-topic link (#22).
- **Per-topic notes-count badge** on the live agenda timeline — each upcoming/projected topic card now shows "No notes" or "N notes" so it's obvious at a glance which topics haven't been covered yet (#26).

## Changes

**`src/views/meeting/MeetingMinutes.tsx` / `.css`**
- Removed the read-only gate on `PostMeetingMinutes`: officers now see the same `+ Text` / `+ Action Item` / `+ Motion` add buttons and `Edit`/`×` controls that were previously only available on a live meeting, reusing the existing `EditableNote`/`CompletedMinuteNotes` machinery (no backend changes needed — the mutations were never gated on meeting status, only on role).
- Threaded a `completion` control through `EditableNote`/`CompletedMinuteNotes` so the action-item completion checkbox (from the previous milestone) keeps working now that this view is editable, for both officers (toggle any item) and the assignee (toggle their own).
- Added `collectIntegrityIssues` (pure helper) and `IntegrityBanner` (shared component), used in both the live and finalized views. Live view supports click-to-jump via `handleSelectTopic`; finalized view uses anchor links (`#minute-<topicId>`) since there's no agenda state to jump within.
- Added `notesCountForAgendaItem` + a badge on each timeline card in the live agenda view.
- Added the "Export as Word (.docx)" button and `handleExportDocx`, which maps the meeting to the docx model and triggers a browser download of the generated blob.

**`src/docx/` (new)**
- `model.ts` — local restatement of minutes-taker's `minutes-model` types needed for export, with two documented deviations: `Person` only ever has a `lastName` (prepare-to-board board members are a single name string, no title/first/last split), and `MotionNote.seconder` is optional (our motion form doesn't require one).
- `style.ts` — verbatim port of minutes-taker's Word style definitions, so exported documents look consistent with that app's output.
- `doc.ts` — ported `exportSessionToDocx` and its helpers from minutes-taker, adapted to drop link-note support (no such note type here) and to guard against zero-topic / zero-calendar-entry meetings, which the original didn't need to handle.
- `mapMeetingToSession.ts` — new adapter from this app's `Meeting`/`Organization`/`BoardMember` shapes into the docx model. Attendance, location, committee, and past-action-item data aren't tracked yet in this app, so those sections render as empty placeholders — tracked as follow-up milestone #8 ("Meeting Minutes DOCX Parity"), deliberately out of scope here.

## Test plan

Ran `tsc -b`, `yarn build`, `yarn lint`, and `yarn test` (typecheck-only in this repo) — all clean.

Then drove the app in the browser against a real completed meeting with mixed note types:
- [x] Edited a finalized meeting: added a new motion (with mover/seconder/vote counts/outcome) and a new text note directly on the completed-meeting page — persisted and rendered correctly, confirming minutes are genuinely editable post-completion.
- [x] Confirmed the action-item completion checkbox still works on the finalized page after this change (toggled complete/incomplete, checked it round-trips through Convex).
- [x] Set a motion's status to "Under Discussion" — the integrity banner appeared with a jump link to the topic; set it back to "Passed" — banner disappeared (confirmed reactivity in both directions).
- [x] Verified the notes-count badge on the live agenda timeline shows "No notes" on untouched projected topics and "1 note" on the active topic once a note was added.
- [x] Exported the `.docx` file and verified the actual generated file, not just that the button didn't crash: intercepted the generated `Blob` in-page, confirmed it's a valid non-empty ZIP (docx magic bytes `PK\x03\x04`) with all the expected internal parts (`word/document.xml`, `styles.xml`, etc.), then parsed the ZIP and decompressed `document.xml` myself to check the actual text content matched what was on screen — organization name, date, both action items (with correct assignee/due date), the motion (mover/seconder/vote tally/outcome), the text note, and the merged "Action Items" summary section with correct "(Added)"/"(Done)" markers.
  - This caught two real bugs before they shipped: `docx`'s `Table` constructor throws on an empty rows array, which crashed the export outright since this app doesn't populate calendar data yet (fixed by skipping the calendar section when empty); and the initial mapping marked every open (non-completed) action item as "(Carried forward)" instead of "(Added)", because minutes-taker's `completed: false` means "brought over from a previous meeting" — a distinction this app doesn't have data for yet, so open items now map to `completed: undefined` instead.

Screenshots from this pass were shared with the requester directly in chat (not embedded here, since there's no image-hosting step in this workflow).

## Notes for reviewers

- Out of scope, deliberately (tracked in milestone #8): attendance lists, meeting location/title/subtitle, board calendar items, committees, and a true "past action items carried forward across meetings" list all render as empty/placeholder sections in the exported document, since this app doesn't have that data yet.
- Left the test motion/text-note additions from manual testing in the dev Convex deployment (same disposable "Mon, Aug 10, 2026" completed meeting used for prior milestone testing) — flagging rather than deleting, per the same reasoning as the last PR.